### PR TITLE
Fix for parsing of port from URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ var Odoo = function (config) {
     this.username = config.username;
     this.password = config.password;
     this.secure = true;
-    if(urlparts.scheme !== 'https:') {
+    if(urlparts.protocol !== 'https:') {
       this.secure = false
     }
     var uid = 0;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,17 +7,19 @@
 *
 */
 var xmlrpc = require('xmlrpc');
+var url = require('url');
 
 var Odoo = function (config) {
     config = config || {};
 
-    this.host = config.url.replace(/https*:\/\//, '');
-    this.port = config.port || null;
+    var urlparts = url.parse(config.url);
+    this.host = urlparts.hostname;
+    this.port = config.port || urlparts.port;
     this.db = config.db;
     this.username = config.username;
     this.password = config.password;
     this.secure = true;
-    if(config.url.substring(0, 5) !== 'https') {
+    if(urlparts.scheme !== 'https:') {
       this.secure = false
     }
     var uid = 0;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "npm": ">=1.0.0"
   },
   "dependencies": {
-    "xmlrpc": "^1.3.1"
+    "xmlrpc": "^1.3.1",
+    "url": "*"
   },
   "license": "Apache-2.0",
   "scripts": {},


### PR DESCRIPTION
The 'replace' isn't stripping the port, so host is being left as 'hostname.com:1234', which fails subsequent DNS lookup.