### PR TITLE
Handle when 'authenticate' returns a value of 'false'.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,9 @@ var Odoo = function (config) {
             if(error){
               return callback(error, null)
             }
+            if(!value){
+              return callback({ message: "No UID returned from authentication." }, null)
+            }
             uid = value;
             return callback(null)
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,12 +33,9 @@ var Odoo = function (config) {
         var client;
         if(this.secure == false) {
           client = xmlrpc.createClient(clientOptions);
-          console.log("client normal")
         }
         else {
           client = xmlrpc.createSecureClient(clientOptions);
-          console.log(clientOptions)
-          console.log("client sécurisé sur le port " + this.port)
         }
         var params = [];
         params.push(this.db);


### PR DESCRIPTION
If 'authenticate' returns 'false', subsequent calls pass 'false' as the UID all the way through to the postgres SQL query, which then raises an SQL exception and things break at that point, and developers get confused as to what's going on, because it seems like the 'connect' worked fine.

This patch avoids it getting that far by raising an error to the caller of 'connect' to let them know it didn't actually connect successfully.

Also, drops a couple of stray debug lines that make a mess in my console when I use this library :)