### PR TITLE
Pass uid of connected user

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ var Odoo = function (config) {
               return callback(error, null)
             }
             uid = value;
-            return callback(null)
+            return callback(null,value)
         });
     };
     this.execute_kw = function(model, method, params, callback){


### PR DESCRIPTION
Pass uid of connected user as second parameter of the `connect()` callback.

In my case it is required in order to call the `create` method of `account.analytic.line`.